### PR TITLE
スケジュール追加用のUIを追加

### DIFF
--- a/frontend/src/components/GanttChart.vue
+++ b/frontend/src/components/GanttChart.vue
@@ -1,7 +1,7 @@
 <template>
   <div class="gantt-chart">
     <schedule-title-list :schedules="schedules"></schedule-title-list>
-    <schedule-table :schedule="schedules"></schedule-table>
+    <schedule-table :schedule="schedules" @scroll="onScroll"></schedule-table>
   </div>
 </template>
 
@@ -27,7 +27,8 @@
 <script>
 import ScheduleTable from './ScheduleTable'
 import ScheduleTitleList from './ScheduleTitleList'
-import { schedules } from '../vuex/getters'
+import { schedules, table } from '../vuex/getters'
+import { setTable } from '../vuex/actions'
 
 export default {
   components: {
@@ -36,7 +37,8 @@ export default {
   },
 
   vuex: {
-    getters: { schedules }
+    getters: { schedules, table },
+    actions: { setTable }
   },
 
   methods: {

--- a/frontend/src/components/ScheduleTable.vue
+++ b/frontend/src/components/ScheduleTable.vue
@@ -4,6 +4,8 @@
     <schedule-table-row
       v-for="schedule in schedules | orderBy compareSchedule"
       :schedule="schedule"></schedule-table-row>
+    <schedule-table-row :schedule="{ isNew: true, startOn: '', endOn: ''}">
+    </schedule-table-row>
   </div>
 </template>
 

--- a/frontend/src/components/ScheduleTableHandle.vue
+++ b/frontend/src/components/ScheduleTableHandle.vue
@@ -32,12 +32,6 @@ export default {
     getters: { table, tableCell, handle }
   },
 
-  watch: {
-    date (v) {
-      console.log('watch', v)
-    }
-  },
-
   data () {
     return {
       _date: null,

--- a/frontend/src/components/ScheduleTableHandle.vue
+++ b/frontend/src/components/ScheduleTableHandle.vue
@@ -32,6 +32,12 @@ export default {
     getters: { table, tableCell, handle }
   },
 
+  watch: {
+    date (v) {
+      console.log('watch', v)
+    }
+  },
+
   data () {
     return {
       _date: null,

--- a/frontend/src/components/ScheduleTableRow.vue
+++ b/frontend/src/components/ScheduleTableRow.vue
@@ -51,7 +51,7 @@ import ScheduleTableHandle from './ScheduleTableHandle'
 import ScheduleComparable from '../mixins/ScheduleComparable'
 import ScheduleMeasurement from '../mixins/ScheduleMeasurement'
 import { tableLength, tableHeaders, tableCell, table } from '../vuex/getters'
-import { setSchedule } from '../vuex/actions'
+import { setSchedule, addSchedule } from '../vuex/actions'
 
 export default {
   mixins: [ScheduleComparable, ScheduleMeasurement],
@@ -63,7 +63,7 @@ export default {
 
   vuex: {
     getters: { tableLength, tableHeaders, tableCell, table },
-    actions: { setSchedule }
+    actions: { setSchedule, addSchedule }
   },
 
   props: {
@@ -118,6 +118,16 @@ export default {
   },
 
   methods: {
+    createSchedule () {
+      const newSchedule = Object.assign({}, this.currentSchedule)
+      newSchedule.isNew = false
+      this.createStatus = 'startOn'
+      this.currentSchedule.startOn = null
+      this.currentSchedule.endOn = null
+
+      this.addSchedule(newSchedule)
+    },
+
     update () {
       this.setSchedule(this.schedule, 'startOn', this.currentSchedule.startOn)
       this.setSchedule(this.schedule, 'endOn', this.currentSchedule.endOn)
@@ -162,16 +172,16 @@ export default {
     },
 
     onClick (e) {
-      console.log(e)
+      if (!this.schedule.isNew) return
+
       switch (this.createStatus) {
         case 'startOn':
           this.createStatus = 'endOn'
           break
         case 'endOn':
           this.createStatus = 'finished'
+          this.createSchedule()
           break
-        case 'finished':
-          // 何かやる。多分スケジュールの追加処理
       }
     },
 

--- a/frontend/src/components/ScheduleTitleList.vue
+++ b/frontend/src/components/ScheduleTitleList.vue
@@ -8,7 +8,7 @@
       :schedule="schedule"
       :style="[scheduleStyle]">
       <div class="title">{{ schedule.title }}</div>
-      <div class="period">
+      <div class="period" v-if="!schedule.isNew">
         {{ schedule.startOn | dateFormat 'YYYY/MM/DD' }} ―
         {{ schedule.endOn | dateFormat 'YYYY/MM/DD' }}
       </div>


### PR DESCRIPTION
## やりたいこと

スケジュールをサクサク追加できるようにしたい
## やったこと
- [x] 開始日と終了日をマウス操作で設定できるようにした
  - マウスクリックで開始日と終了日を設定できる
- [x] 設定中の開始日と終了日をマーカーで表示するようにした
- [x] Esc キーで設定した開始日を取り消すことができる
## やらなかったこと
- タイトル設定
## マージ後のタスク
- タイトルを変更できるようにする
- タイトルのみの日付未設定スケジュールを追加できるようにする #11 
  - 日付はあとで設定できるようにする
- ScheduleTableRow のリファクタリング。日付未設定時と設定後でコンポーネントを分割する #10 
- きれいな見た目のマーカー
## イメージ

[![https://gyazo.com/4d3afc0e60f03951d9c8b06a13fa493e](https://i.gyazo.com/4d3afc0e60f03951d9c8b06a13fa493e.gif)](https://gyazo.com/4d3afc0e60f03951d9c8b06a13fa493e)

[![https://gyazo.com/ab456265ff5618d93ffde0ca53cb5bd7](https://i.gyazo.com/ab456265ff5618d93ffde0ca53cb5bd7.gif)](https://gyazo.com/ab456265ff5618d93ffde0ca53cb5bd7)
